### PR TITLE
Disable 'Previous' and 'Next' Buttons Based on Selected Departure Date

### DIFF
--- a/src/components/SearchForm/SearchForm.module.css
+++ b/src/components/SearchForm/SearchForm.module.css
@@ -169,6 +169,14 @@ select:focus {
   background-color: #226f3a;
 }
 
+.button:disabled {
+  background-color: #cccccc;
+  color: #666666;
+  cursor: not-allowed;
+  opacity: 0.7;
+  box-shadow: none;
+}
+
 @media (max-width: 768px) {
   .container {
     padding: 1rem;

--- a/src/components/SearchForm/SearchForm.test.tsx
+++ b/src/components/SearchForm/SearchForm.test.tsx
@@ -326,4 +326,86 @@ describe("Test for FlightSearchForm />", () => {
       expect(screen.queryByRole("button", { name: /Next/i })).not.toBeInTheDocument();
     });
   });
+
+  it("should disable previous button if date is today", async () => {
+    const today = new Date().toISOString().split("T")[0];
+    const mockFlights: FlightSearchResult[] = [
+      {
+        flight_number: "F100",
+        source: "Mumbai",
+        destination: "Delhi",
+        departure_time: `${today}T10:00:00Z`,
+        arrival_time: `${today}T14:00:00Z`,
+        total_fare: 500,
+        departure_date: today,
+        arrival_date: today,
+        class_type: "economy",
+        economy_seats: 10,
+        business_seats: 10,
+        first_class_seats: 10,
+        price_per_person: 10,
+        base_price: 10,
+        extra_price: 10,
+      },
+    ];
+    vi.mocked(fetchFlights).mockResolvedValueOnce(mockFlights);
+
+    renderWithCitiesContext();
+    fireEvent.change(screen.getByLabelText(/source/i), {
+      target: { name: "source", value: "Mumbai" },
+    });
+    fireEvent.change(screen.getByLabelText(/destination/i), {
+      target: { name: "destination", value: "Delhi" },
+    });
+    fireEvent.change(screen.getByLabelText(/departure date/i), {
+      target: { name: "date", value: today },
+    });
+    fireEvent.submit(screen.getByRole("button", { name: /Search Flights/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Previous/i })).toBeDisabled();
+    });
+  });
+
+  it("should disable next button if date is max date", async () => {
+    const maxDate = new Date(new Date().setMonth(new Date().getMonth() + 3))
+      .toISOString()
+      .split("T")[0];
+    const mockFlights: FlightSearchResult[] = [
+      {
+        flight_number: "F200",
+        source: "Mumbai",
+        destination: "Delhi",
+        departure_time: `${maxDate}T09:00:00Z`,
+        arrival_time: `${maxDate}T12:00:00Z`,
+        total_fare: 450,
+        departure_date: maxDate,
+        arrival_date: maxDate,
+        class_type: "economy",
+        economy_seats: 10,
+        business_seats: 10,
+        first_class_seats: 10,
+        price_per_person: 10,
+        base_price: 10,
+        extra_price: 10,
+      },
+    ];
+    vi.mocked(fetchFlights).mockResolvedValueOnce(mockFlights);
+
+    renderWithCitiesContext();
+    fireEvent.change(screen.getByLabelText(/source/i), {
+      target: { name: "source", value: "Mumbai" },
+    });
+    fireEvent.change(screen.getByLabelText(/destination/i), {
+      target: { name: "destination", value: "Delhi" },
+    });
+    fireEvent.change(screen.getByLabelText(/departure date/i), {
+      target: { name: "date", value: maxDate },
+    });
+    fireEvent.submit(screen.getByRole("button", { name: /Search Flights/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Next/i })).toBeDisabled();
+    });
+  });
 });

--- a/src/components/SearchForm/SearchForm.tsx
+++ b/src/components/SearchForm/SearchForm.tsx
@@ -24,6 +24,14 @@ export function FlightSearchForm() {
   const [alertMessage, setAlertMessage] = useState<string | null>(null);
   const [failure, setFailure] = useState(false);
 
+  const today = new Date();
+  const maxDate = new Date(new Date().setMonth(today.getMonth() + 3));
+  const todayStr = today.toISOString().split("T")[0];
+  const maxDateStr = maxDate.toISOString().split("T")[0];
+
+  const isPrevDisabled = formData.date === todayStr;
+  const isNextDisabled = formData.date === maxDateStr;
+
   const refresh = async () => {
     setLoading(true);
     await refetch();
@@ -182,8 +190,12 @@ export function FlightSearchForm() {
       {searched && (
         <>
           <div className={styles.buttons_container}>
-            <button className={styles.button}>Previous</button>
-            <button className={styles.button}>Next</button>
+            <button className={styles.button} disabled={isPrevDisabled}>
+              Previous
+            </button>
+            <button className={styles.button} disabled={isNextDisabled}>
+              Next
+            </button>
           </div>
           <FlightsDisplay flights={flights} passengers={formData.passengers} />
         </>


### PR DESCRIPTION
This PR disables the 'Previous' and 'Next' navigation buttons in the `FlightSearchForm` component based on the selected departure date:

- **'Previous'** button is disabled if the selected date is **today**.
- **'Next'** button is disabled if the selected date is the **last available date** (i.e., 3 months from today).

### Changes Made
- Updated `SearchForm.tsx` to compute and compare dates using the existing `min` and `max` date logic.
- Added CSS styles to reflect the disabled state of the navigation buttons.
- Wrote test cases to verify button disabling behaviour using mocked flight data.


### **_Previous button disabled (today selected_**)
<img width="1440" height="821" alt="Screenshot 2025-07-16 at 13 34 22" src="https://github.com/user-attachments/assets/4a1f4244-4d57-481d-a544-118e0ca00554" />

### **_Next button disabled (max date selected)_**
<img width="1440" height="821" alt="Screenshot 2025-07-16 at 13 34 11" src="https://github.com/user-attachments/assets/1ac6f815-4a09-49e0-8153-ff236cff88de" />

