### PR TITLE
Validate flight search form inputs and handle invalid city selection

### DIFF
--- a/src/components/SearchForm/SearchForm.test.tsx
+++ b/src/components/SearchForm/SearchForm.test.tsx
@@ -31,7 +31,6 @@ const renderWithCitiesContext = (
 };
 
 describe("Test for FlightSearchForm />", () => {
-
   it("should render cities in datalists", () => {
     renderWithCitiesContext({ cities: ["Mumbai", "Delhi", "Bangalore"] });
     const datalist = document.querySelector("#source-list");
@@ -541,5 +540,29 @@ describe("Test for FlightSearchForm />", () => {
     });
 
     expect(screen.queryByText(/F300/i)).not.toBeInTheDocument();
+  });
+  it("should show error for invalid city", async () => {
+    renderWithCitiesContext({ cities: ["Mumbai", "Delhi"] });
+
+    const sourceInput = screen.getByLabelText(/source/i);
+    const destinationInput = screen.getByLabelText(/destination/i);
+    const dateInput = screen.getByLabelText(/date/i);
+    const passengersInput = screen.getByLabelText(/passengers/i);
+    const classSelect = screen.getByLabelText(/class/i);
+    const searchButton = screen.getByRole("button", {
+      name: /search flights/i,
+    });
+
+    fireEvent.change(sourceInput, { target: { value: "InvalidCity" } });
+    fireEvent.change(destinationInput, { target: { value: "Delhi" } });
+    fireEvent.change(dateInput, { target: { value: "2025-07-22" } });
+    fireEvent.change(passengersInput, { target: { value: "2" } });
+    fireEvent.change(classSelect, { target: { value: "economy" } });
+
+    fireEvent.click(searchButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/invalid city selected/i)).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/SearchForm/SearchForm.tsx
+++ b/src/components/SearchForm/SearchForm.tsx
@@ -54,6 +54,11 @@ export function FlightSearchForm() {
   const fetchAndSetFlights = async (data: FlightSearchFormData) => {
     setFlightsLoading(true);
     try {
+      if (!cities.includes(data.source) || !cities.includes(data.destination)) {
+        setSearched(false);
+        setAlertMessage("Invalid City selected.");
+        return;
+      }
       const results = await fetchFlights(data);
       setFlights(results);
       setSearched(true);


### PR DESCRIPTION
This PR adds validation logic to the Flight Search form to ensure only valid cities are accepted for source and destination. 

### Changes Made
- Added validation in the `FlightSearchForm` to check `source` and `destination` against the `cities` list from context.
- Displayed error message for invalid cities.
- Prevented API call (`fetchFlights`) when cities are invalid.


### Test Coverage
-  Added a test case to check this functionality.
- All test cases are passed.
