### PR TITLE
Add code to display recurrent days in the UI

### DIFF
--- a/src/components/FlightDisplay/FlightDisplay.module.css
+++ b/src/components/FlightDisplay/FlightDisplay.module.css
@@ -100,6 +100,11 @@
   color: black;
 }
 
+.recurrenceDays{
+  color:  rgb(71, 134, 134);
+  font-size: 0.8rem;
+}
+
 .book {
   display: flex;
   flex-direction: column;

--- a/src/components/FlightDisplay/FlightDisplay.test.tsx
+++ b/src/components/FlightDisplay/FlightDisplay.test.tsx
@@ -20,6 +20,7 @@ const mockFlight: FlightSearchResult = {
   extra_price: 50,
   price_per_person: 350,
   total_fare: 700,
+  recurrence_days: "One Time Flight"
 };
 
 describe("FlightDisplay", () => {
@@ -31,6 +32,7 @@ describe("FlightDisplay", () => {
     expect(screen.getByText("2025-07-21 at 12:00 AM")).toBeInTheDocument();
     expect(screen.getByText("ECONOMY")).toBeInTheDocument();
     expect(screen.getByText("50")).toBeInTheDocument();
+    expect(screen.getByText("One Time Flight")).toBeInTheDocument();
     expect(
       screen.getByText("Total Fare for 2 passengers:")
     ).toBeInTheDocument();

--- a/src/components/FlightDisplay/FlightDisplay.tsx
+++ b/src/components/FlightDisplay/FlightDisplay.tsx
@@ -57,6 +57,7 @@ function FlightDisplay({
               <div className={styles.durationCircle}></div>
             </div>
           </div>
+          <p className={styles.recurrenceDays}>{flight.recurrence_days}</p>
           <div className={styles.topRightSection}>
             <span className={styles.flightNumber}>{classTypeFormatted}</span>
             <span className={styles.flightNumber}>
@@ -95,7 +96,9 @@ function FlightDisplay({
               <div>
                 Dynamic Price: <span>{convertCurrency(flight.extra_price,selectedCurrency)}</span>
               </div>
+              
             </div>
+            
           </div>
 
           <div className={styles.book}>

--- a/src/components/FlightsDisplay/FlightsDisplay.test.tsx
+++ b/src/components/FlightsDisplay/FlightsDisplay.test.tsx
@@ -12,11 +12,12 @@ const mockFlights: FlightSearchResult[] = [
     arrival_date: "2025-07-20",
     arrival_time: "10:00",
     class_type: "economy",
-    available_seats:30,
+    available_seats: 30,
     base_price: 150,
     extra_price: 25,
     price_per_person: 175,
     total_fare: 350,
+    recurrence_days: ""
   },
 ];
 

--- a/src/components/SearchForm/SearchForm.test.tsx
+++ b/src/components/SearchForm/SearchForm.test.tsx
@@ -42,6 +42,7 @@ describe("Test for FlightSearchForm />", () => {
   });
 
   it("should update form fields on change", () => {
+    const today = new Date().toISOString().split("T")[0];
     renderWithCitiesContext({
       cities: ["Mumbai", "Delhi"],
     });
@@ -58,9 +59,9 @@ describe("Test for FlightSearchForm />", () => {
     expect(destInput).toHaveValue("Delhi");
     const dateInput = screen.getByLabelText(/departure date/i);
     fireEvent.change(dateInput, {
-      target: { name: "date", value: "2025-08-01" },
+      target: { name: "date", value: today },
     });
-    expect(dateInput).toHaveValue("2025-08-01");
+    expect(dateInput).toHaveValue(today);
     const passengersInput = screen.getByLabelText(/number of passengers/i);
     fireEvent.change(passengersInput, {
       target: { name: "passengers", value: 3 },
@@ -100,6 +101,7 @@ describe("Test for FlightSearchForm />", () => {
         price_per_person: 10,
         base_price: 10,
         extra_price: 10,
+        recurrence_days: ""
       },
     ];
     vi.mocked(fetchFlights).mockResolvedValue(mockFlights);
@@ -174,6 +176,7 @@ describe("Test for FlightSearchForm />", () => {
         price_per_person: 10,
         base_price: 10,
         extra_price: 10,
+        recurrence_days: ""
       },
     ];
 
@@ -228,6 +231,7 @@ describe("Test for FlightSearchForm />", () => {
         price_per_person: 10,
         base_price: 10,
         extra_price: 10,
+        recurrence_days: ""
       },
     ];
     vi.mocked(fetchFlights).mockResolvedValueOnce(mockFlights);
@@ -294,6 +298,7 @@ describe("Test for FlightSearchForm />", () => {
         price_per_person: 10,
         base_price: 10,
         extra_price: 10,
+        recurrence_days: ""
       },
     ];
     vi.mocked(fetchFlights).mockResolvedValueOnce(mockFlights);
@@ -334,6 +339,7 @@ describe("Test for FlightSearchForm />", () => {
         price_per_person: 10,
         base_price: 10,
         extra_price: 10,
+        recurrence_days: ""
       },
     ];
     vi.mocked(fetchFlights).mockResolvedValueOnce(mockFlights);
@@ -374,6 +380,7 @@ describe("Test for FlightSearchForm />", () => {
         price_per_person: 10,
         base_price: 10,
         extra_price: 10,
+        recurrence_days: ""
       },
     ];
 
@@ -392,6 +399,7 @@ describe("Test for FlightSearchForm />", () => {
         price_per_person: 10,
         base_price: 10,
         extra_price: 10,
+        recurrence_days: ""
       },
     ];
 
@@ -447,6 +455,7 @@ describe("Test for FlightSearchForm />", () => {
         price_per_person: 10,
         base_price: 10,
         extra_price: 10,
+        recurrence_days: ""
       },
     ];
 
@@ -465,6 +474,7 @@ describe("Test for FlightSearchForm />", () => {
         price_per_person: 10,
         base_price: 10,
         extra_price: 10,
+        recurrence_days: ""
       },
     ];
 
@@ -517,6 +527,7 @@ describe("Test for FlightSearchForm />", () => {
         price_per_person: 10,
         base_price: 10,
         extra_price: 10,
+        recurrence_days: ""
       },
     ];
 
@@ -553,6 +564,7 @@ describe("Test for FlightSearchForm />", () => {
     expect(screen.queryByText(/F300/i)).not.toBeInTheDocument();
   });
   it("should show error for invalid city", async () => {
+    const today = new Date().toISOString().split("T")[0];
     renderWithCitiesContext({ cities: ["Mumbai", "Delhi"] });
 
     const sourceInput = screen.getByLabelText(/source/i);
@@ -566,7 +578,7 @@ describe("Test for FlightSearchForm />", () => {
 
     fireEvent.change(sourceInput, { target: { value: "InvalidCity" } });
     fireEvent.change(destinationInput, { target: { value: "Delhi" } });
-    fireEvent.change(dateInput, { target: { value: "2025-07-22" } });
+    fireEvent.change(dateInput, { target: { value: today } });
     fireEvent.change(passengersInput, { target: { value: "2" } });
     fireEvent.change(classSelect, { target: { value: "economy" } });
 
@@ -576,4 +588,5 @@ describe("Test for FlightSearchForm />", () => {
       expect(screen.getByText(/invalid city selected/i)).toBeInTheDocument();
     });
   });
+
 });

--- a/src/services/__tests__/BookFlight.test.ts
+++ b/src/services/__tests__/BookFlight.test.ts
@@ -17,6 +17,7 @@ const mockFlight: FlightSearchResult = {
   extra_price: 50,
   price_per_person: 350,
   total_fare: 700,
+  recurrence_days: ""
 };
 
 describe("Tests for bookFlight service", () => {

--- a/src/services/__tests__/FetchFlights.test.ts
+++ b/src/services/__tests__/FetchFlights.test.ts
@@ -26,6 +26,7 @@ const mockFlights: FlightSearchResult[] = [
     price_per_person: 0,
     base_price: 0,
     extra_price: 0,
+    recurrence_days: ""
   },
 ];
 

--- a/src/types/FlightSearchResult.ts
+++ b/src/types/FlightSearchResult.ts
@@ -12,4 +12,5 @@ export type FlightSearchResult = {
   price_per_person: number;
   base_price: number;
   extra_price: number;
+  recurrence_days: string;
 };


### PR DESCRIPTION
This PR introduces the implementation of displaying the flight type in the flight card.

### Changes
- Display `One-Time Flight` for one time flights.
- Week day for flights running on those week days.

### Tests
- Test case is added.
- Existing test cases are modified to support another attribute.