### PR TITLE
Reflect the selected Flight

### DIFF
--- a/src/components/RoundTripFlightDisplay/RoundTripFlightDisplay.module.css
+++ b/src/components/RoundTripFlightDisplay/RoundTripFlightDisplay.module.css
@@ -154,6 +154,10 @@
   display: inline-block;
   margin: 0 auto;
 }
+.selectedCard {
+  border: 2px solid rgba(6, 6, 6, 6);
+  transition: border-color 0.3s ease;
+}
 
 @keyframes spin {
   0% {

--- a/src/components/RoundTripFlightDisplay/RoundTripFlightDisplay.test.tsx
+++ b/src/components/RoundTripFlightDisplay/RoundTripFlightDisplay.test.tsx
@@ -17,7 +17,7 @@ const mockFlight: FlightSearchResult = {
   departure_time: "",
   arrival_time: "",
   price_per_person: 0,
-  recurrence_days: ""
+  recurrence_days: "",
 };
 
 describe("Tests for RoundTripFlightDisplay", () => {
@@ -36,6 +36,8 @@ describe("Tests for RoundTripFlightDisplay", () => {
         tab="onwards"
         isSelected={true}
         setOpen={mockSetOpen}
+        selectedOnward={null}
+        selectedReturn={null}
       />
     );
 
@@ -57,6 +59,8 @@ describe("Tests for RoundTripFlightDisplay", () => {
         tab="onwards"
         isSelected={true}
         setOpen={mockSetOpen}
+        selectedOnward={null}
+        selectedReturn={null}
       />
     );
 
@@ -77,6 +81,8 @@ describe("Tests for RoundTripFlightDisplay", () => {
         tab="return"
         isSelected={true}
         setOpen={mockSetOpen}
+        selectedOnward={null}
+        selectedReturn={null}
       />
     );
 
@@ -98,6 +104,8 @@ describe("Tests for RoundTripFlightDisplay", () => {
         tab="return"
         isSelected={false}
         setOpen={mockSetOpen}
+        selectedOnward={null}
+        selectedReturn={null}
       />
     );
 
@@ -116,10 +124,35 @@ describe("Tests for RoundTripFlightDisplay", () => {
         tab="onwards"
         isSelected={true}
         setOpen={mockSetOpen}
+        selectedOnward={null}
+        selectedReturn={null}
       />
     );
 
     expect(screen.getByText(/Base price:/i)).toBeInTheDocument();
     expect(screen.getByText(/Dynamic Price:/i)).toBeInTheDocument();
+  });
+  it("should apply selectedCard class when flight is selected", () => {
+    render(
+      <RoundTripFlightDisplay
+        flight={mockFlight}
+        passengers={1}
+        selectedCurrency="INR"
+        handleOnwardSelect={mockHandleOnwardSelect}
+        handleReturnSelect={mockHandleReturnSelect}
+        tab="onwards"
+        isSelected={true}
+        setOpen={mockSetOpen}
+        selectedOnward={mockFlight}
+        selectedReturn={null}
+      />
+    );
+    const allDivs = document.querySelectorAll("div");
+
+    const selectedCardExists = Array.from(allDivs).some((div) =>
+      div.className.includes("selectedCard")
+    );
+
+    expect(selectedCardExists).toBe(true);
   });
 });

--- a/src/components/RoundTripFlightDisplay/RoundTripFlightDisplay.tsx
+++ b/src/components/RoundTripFlightDisplay/RoundTripFlightDisplay.tsx
@@ -6,6 +6,8 @@ import type { FlightSearchResult } from "../../types/FlightSearchResult";
 import styles from "./RoundTripFlightDisplay.module.css";
 
 function RoundTripFlightDisplay({
+  selectedOnward,
+  selectedReturn,
   flight,
   passengers,
   selectedCurrency,
@@ -15,6 +17,8 @@ function RoundTripFlightDisplay({
   isSelected,
   setOpen,
 }: {
+  selectedOnward: FlightSearchResult | null;
+  selectedReturn: FlightSearchResult | null;
   flight: FlightSearchResult;
   passengers: number;
   selectedCurrency: string;
@@ -42,7 +46,19 @@ function RoundTripFlightDisplay({
   };
 
   return (
-    <div key={flight.flight_number} className={styles.flightCard}>
+    // <div key={flight.flight_number} className={styles.flightCard }>
+    <div
+      key={flight.flight_number}
+      className={`${styles.flightCard} ${
+        (tab === "onwards" &&
+          selectedOnward?.flight_number === flight.flight_number) ||
+        (tab === "return" &&
+          selectedReturn?.flight_number === flight.flight_number)
+          ? styles.selectedCard
+          : ""
+      }`}
+      onClick={handleSelect}
+    >
       <div className={styles.flightCardContent}>
         <div className={styles.flightCardHeader}>
           <span className={styles.route}>

--- a/src/components/RoundTripFlightsDisplay/RoundTripFlightsDisplay.tsx
+++ b/src/components/RoundTripFlightsDisplay/RoundTripFlightsDisplay.tsx
@@ -64,6 +64,8 @@ export const RoundTripResults: React.FC<Props> = ({
         {(activeTab === "onwards" ? data.onwards : data.return).map(
           (flight: FlightSearchResult, index: number) => (
             <RoundTripFlightDisplay
+              selectedOnward={selectedOnward}
+              selectedReturn={selectedReturn}
               key={index}
               flight={flight}
               passengers={passengers}


### PR DESCRIPTION
This PR introduces the visualisation of the onward and return flight selected for good user experience.
### Implementation:
- Pass the `selectedOnwardFlight` and `selectedReturnFlight` to the component.
- While rendering the component, compare the number of selected flights and the flight number being rendered.
- If same, applying a border colour to it using conditional classNames.

### Tests:
- Implemented test case for this feature.

<img width="1381" height="816" alt="Screenshot 2025-07-29 at 3 34 49 PM" src="https://github.com/user-attachments/assets/562df3d1-35d6-48b8-b7a4-46959dc93de8" />
